### PR TITLE
Unlock skill

### DIFF
--- a/Assets/Scripts/Action/MutualExclusiveAction.cs
+++ b/Assets/Scripts/Action/MutualExclusiveAction.cs
@@ -4,6 +4,13 @@ using UnityEngine;
 
 public abstract class MutualExclusiveAction : CooldownAction
 {
+    public int minScore;
+
+    public bool IsUnlocked()
+    {
+        return minScore < Statics.GetScoreModel().GetScore();
+    }
+
     public override void Start()
     {
         base.Start();

--- a/Assets/Scripts/Action/MutualExclusiveActionExecutor.cs
+++ b/Assets/Scripts/Action/MutualExclusiveActionExecutor.cs
@@ -22,9 +22,9 @@ public class MutualExclusiveActionExecutor : MonoBehaviour
         action.Update();
 
         // Handle control
-        if (Input.GetKeyDown(KeyBindings.GetKeyBinding("cooldown_action")))
+        if (Input.GetKeyDown(KeyBindings.GetKeyBinding("cooldown_action")) &&
+            action.IsUnlocked())
         {
-            Debug.Log("Action is unlocked. " + action.IsUnlocked());
             action.Trigger();
         }
     }

--- a/Assets/Scripts/Action/MutualExclusiveActionExecutor.cs
+++ b/Assets/Scripts/Action/MutualExclusiveActionExecutor.cs
@@ -23,6 +23,9 @@ public class MutualExclusiveActionExecutor : MonoBehaviour
 
         // Handle control
         if (Input.GetKeyDown(KeyBindings.GetKeyBinding("cooldown_action")))
+        {
+            Debug.Log("Action is unlocked. " + action.IsUnlocked());
             action.Trigger();
+        }
     }
 }

--- a/Assets/Scripts/Fighting/SpellCasting.cs
+++ b/Assets/Scripts/Fighting/SpellCasting.cs
@@ -38,7 +38,7 @@ namespace Fighting
             // Nothing can be done, when the spell cooldown is
             // still active. Neither spells can be thrown, nor
             // can spells be swapped during this period of time
-            if (castSpellAction.waiting)
+            if (castSpellAction.active || castSpellAction.waiting)
                 return;
 
             // Change spell when pressing space

--- a/Assets/Scripts/Highscores/Highscores.cs
+++ b/Assets/Scripts/Highscores/Highscores.cs
@@ -40,11 +40,8 @@ namespace DefaultNamespace
         
         public static void SaveHighscore()
         {
-            var hud = GameObject.Find("/HUD");
-            if (!hud) return;
-
-            var score = new Highscore(hud.GetComponent<ScoreModel>().GetScore());
-
+            var score = new Highscore(Statics.GetScoreModel().GetScore());
+            
             var highscore = _highscores.Count == 0 ? new Highscore(-1) : _highscores[0];
             if (score.score <= highscore.score) return;
 

--- a/Assets/Scripts/Utilities.meta
+++ b/Assets/Scripts/Utilities.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 31221beca142ee86cb969a09bc8ce905
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utilities/Initialization.cs
+++ b/Assets/Scripts/Utilities/Initialization.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Initialization : MonoBehaviour
+{
+    void Start()
+    {
+        Statics.Initialize();
+    }
+}

--- a/Assets/Scripts/Utilities/Initialization.cs.meta
+++ b/Assets/Scripts/Utilities/Initialization.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd7872a43febc8b84a5960f2282fb950
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utilities/Statics.cs
+++ b/Assets/Scripts/Utilities/Statics.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class Statics
+{
+    private static ScoreModel scoreModel;
+    private static WaveIndicatorView waveIndicator;
+
+    public static void Initialize()
+    {
+        scoreModel = GameObject.FindGameObjectsWithTag("Score")[0]
+                               .GetComponent<ScoreModel>();
+
+        waveIndicator = GameObject.FindGameObjectsWithTag("WaveIndicator")[0]
+                                  .GetComponent<WaveIndicatorView>();        
+        waveIndicator.Start();
+    }
+
+    public static ScoreModel GetScoreModel()
+    {
+        return scoreModel;
+    }
+
+    public static WaveIndicatorView GetWaveIndicator()
+    {
+        return waveIndicator;
+    }
+}

--- a/Assets/Scripts/Utilities/Statics.cs.meta
+++ b/Assets/Scripts/Utilities/Statics.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 067db945debf3d0a59e16ef2f2467aae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/WaveManager.cs
+++ b/Assets/Scripts/WaveManager.cs
@@ -28,20 +28,8 @@ public class WaveManager : MonoBehaviour
     public float strength;
     private List<GameObject> minions;
 
-    //-- [Visual Components] -----------------------------
-    public ScoreModel score;
-    public WaveIndicatorView waveIndicator;
-
     void Start()
     {
-        // Retrieving visual components for later updates
-        score = GameObject.FindGameObjectsWithTag("Score")[0]
-                          .GetComponent<ScoreModel>();
-
-        waveIndicator = GameObject.FindGameObjectsWithTag("WaveIndicator")[0]
-                                  .GetComponent<WaveIndicatorView>();        
-        waveIndicator.Start();
-
         //Getting "Attacker" component of game objects beforehand
         //to elimite "runtime" overhead during the game and sort
         //them in ascending order regarding their strength.
@@ -80,7 +68,7 @@ public class WaveManager : MonoBehaviour
             // management loop. In other words, the 0th wave immediatly
             // finishes and the wave with index 1 is the actual first wave.
             if (wave > 0)
-                waveIndicator.UpdateView(wave); 
+                Statics.GetWaveIndicator().UpdateView(wave); 
 
             // Update wave stats
             wave++;
@@ -118,13 +106,9 @@ public class WaveManager : MonoBehaviour
     public void ReportDeath(GameObject entity)
     {
         if (minions.Contains(entity)) {
-            // Retrieve score field
-            GameObject scoreField = GameObject.FindGameObjectsWithTag("Score")[0];
-            ScoreModel view = scoreField.GetComponent<ScoreModel>();
-
             // Retrieve attacker strength and increment score accordingly
             Attacker attacker = entity.GetComponent<Attacker>();
-            view.Increment((int) attacker.GetStrength());
+            Statics.GetScoreModel().Increment((int) attacker.GetStrength());
 
             // Remove the entity and drop reward
             GenerateDrop(entity.transform.position);

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.25f1
-m_EditorVersionWithRevision: 2020.3.25f1 (9b9180224418)
+m_EditorVersion: 2020.3.21f1
+m_EditorVersionWithRevision: 2020.3.21f1 (a38c86f6690f)


### PR DESCRIPTION
Would be nice, if you took a look at it!

It is a fairly small change. There are two main things being done here. First, components such as the ScoreModel are made statically available. For this, the "Initialization" script is attached to the player. There static initializations can be triggered. After that, the ScoreModel is available at every location at any time without retrieving the component via its ID, when needed.

(Also, the WaveIndicatorView has been made statically available too - felt the urge)

I then applied this at some locations, I immediately noticed are using the "unstatic version" of accessing the score.
Please, if you know code where the old method is used, apply the static version, as it is more clean and probably faster.

All that being said, that was prelude for checking if the score has exceeded the minimum score for a skill to be unlocked in a clean and fast manner :^)

(about the spell casting thing in that PR - that comes from here: https://github.com/Wizards-vs-Robots/wvr/commit/0ed211b463b0d6223a53113e9d3a18e7d65209df. I do not know how that got into here, as this has been put into the commit at which I branched)